### PR TITLE
Add i18n support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,18 +3,19 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "coveralls": "^2.13.1",
-    "husky": "^0.14.3",
-    "lint-staged": "^4.2.1",
     "material-ui": "^1.0.0-beta.12",
     "material-ui-icons": "^1.0.0-beta.10",
-    "prettier": "^1.7.0",
+    "proptypes": "^1.1.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-helmet": "^5.2.0",
+    "react-intl": "^2.4.0",
+    "react-redux": "^5.0.6",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
     "react-scripts": "1.0.13",
+    "redux": "^3.7.2",
+    "redux-actions": "^2.2.1",
     "source-map-explorer": "^1.4.0",
     "styled-components": "^2.1.2"
   },
@@ -28,7 +29,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
-    "ci-test": "CI=true react-scripts test --env=jsdom --coverage --collectCoverageFrom=**/app/*.{js,jsx} && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
+    "ci-test": "CI=true react-scripts test --env=jsdom --coverage --collectCoverageFrom=**/app/**/*.{js,jsx} && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 9009 -s public",
     "build-storybook": "build-storybook -s public",
@@ -38,6 +39,14 @@
   "devDependencies": {
     "@storybook/addon-actions": "^3.2.6",
     "@storybook/addon-links": "^3.2.6",
-    "@storybook/react": "^3.2.8"
+    "@storybook/react": "^3.2.8",
+    "coveralls": "^2.13.1",
+    "enzyme": "^3.0.0",
+    "enzyme-adapter-react-16": "^1.0.0",
+    "husky": "^0.14.3",
+    "lint-staged": "^4.2.1",
+    "prettier": "^1.7.0",
+    "react-test-renderer": "^16.0.0",
+    "redux-mock-store": "^1.3.0"
   }
 }

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1,20 +1,45 @@
-import React, { Component } from 'react';
-import {Helmet} from 'react-helmet';
+//React libs
+import React from 'react';
+import BrowserRouter from 'react-router-dom/BrowserRouter';
+import { IntlProvider } from 'react-intl';
+import { createStore } from 'redux';
+import { connect, Provider } from 'react-redux';
+
+//App imports
 import Header from './components/Header';
 import Slider from './components/Slider';
+import HelmetIntl from './components/HelmetIntl';
+import diasposhipApp from './reducers';
+import { selectLanguage } from './actions/translation';
 
-class App extends Component {
-  render() {
-    return (
-      <div className="App">
-        <Helmet>
-          <title>Ship your stuff with Diaspoship!</title>
-        </Helmet>
+let store = createStore(diasposhipApp);
+store.dispatch(selectLanguage(window.navigator.language.split('-')[0]));
+
+const AppBody = ({ selectedLanguage, selectedTranslations }) => (
+  <IntlProvider locale={selectedLanguage} messages={selectedTranslations}>
+    <BrowserRouter>
+      <div>
+        <HelmetIntl messageId="pages.home.title" />
         <Header />
         <Slider />
       </div>
-    );
-  }
-}
+    </BrowserRouter>
+  </IntlProvider>
+);
+
+const mapStateToProps = ({
+  translation: { selectedLanguage, selectedTranslations }
+}) => ({
+  selectedLanguage,
+  selectedTranslations
+});
+
+const AppBodyWithState = connect(mapStateToProps)(AppBody);
+
+const App = () => (
+  <Provider store={store}>
+    <AppBodyWithState />
+  </Provider>
+);
 
 export default App;

--- a/src/app/actions/translation.js
+++ b/src/app/actions/translation.js
@@ -1,0 +1,3 @@
+import { createAction } from 'redux-actions';
+
+export const selectLanguage = createAction('SET_LANGUAGE');

--- a/src/app/components/Header.js
+++ b/src/app/components/Header.js
@@ -1,10 +1,18 @@
+// React
 import React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes from 'proptypes';
+import { FormattedMessage } from 'react-intl';
+
+//Material-UI
 import { withStyles } from 'material-ui/styles';
 import AppBar from 'material-ui/AppBar';
 import Toolbar from 'material-ui/Toolbar';
 import Typography from 'material-ui/Typography';
 import Button from 'material-ui/Button';
+
+//App Imports
+import LanguageSelector from './LanguageSelector';
+
 const styles = theme => ({
   root: {
     width: '100%'
@@ -17,6 +25,7 @@ const styles = theme => ({
     marginRight: 20
   }
 });
+
 function Header(props) {
   const classes = props.classes;
   return (
@@ -26,9 +35,16 @@ function Header(props) {
           <Typography type="title" color="inherit" className={classes.flex}>
             DIASPOSHIP
           </Typography>
-          <Button>S'inscrire</Button>
-          <Button>Se conneceter</Button>
-          <Button>Comment ça marche</Button>
+          <LanguageSelector />
+          <Button>
+            <FormattedMessage id="components.header.buttons.signup" />
+          </Button>
+          <Button>
+            <FormattedMessage id="components.header.buttons.login" />
+          </Button>
+          <Button>
+            <FormattedMessage id="components.header.buttons.help" />
+          </Button>
         </Toolbar>
       </AppBar>
     </div>

--- a/src/app/components/HelmetIntl.js
+++ b/src/app/components/HelmetIntl.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import { injectIntl, intlShape } from 'react-intl';
+import PropTypes from 'proptypes';
+
+export const HelmetIntl = ({
+  intl: { formatMessage },
+  messageId,
+  ...props
+}) => (
+  <Helmet
+    title={formatMessage({
+      id: messageId,
+      defaultMessage: props.defaultMessage
+    })}
+    {...props}
+  />
+);
+
+HelmetIntl.propTypes = {
+  intl: intlShape.isRequired,
+  messageId: PropTypes.string.isRequired
+};
+
+export default injectIntl(HelmetIntl);

--- a/src/app/components/LanguageSelector.js
+++ b/src/app/components/LanguageSelector.js
@@ -1,0 +1,44 @@
+//React
+import React from 'react';
+import PropTypes from 'proptypes';
+import { connect } from 'react-redux';
+import { FormattedMessage } from 'react-intl';
+
+//Material-UI
+import Select from 'material-ui/Select';
+import Input from 'material-ui/Input';
+
+//App Imports
+import { selectLanguage } from '../actions/translation';
+import { AVAILABLE_LANGUAGES } from '../constants';
+
+export const LanguageSelector = ({ selectedLanguage, onSelectLanguage }) => (
+  <Select
+    native
+    name="language-selector"
+    value={selectedLanguage}
+    onChange={event => onSelectLanguage(event.target.value)}
+    input={<Input />}
+  >
+    {Object.keys(AVAILABLE_LANGUAGES).map(language => (
+      <FormattedMessage key={language} id={`languages.${language}`}>
+        {languageName => <option value={language}>{languageName}</option>}
+      </FormattedMessage>
+    ))}
+  </Select>
+);
+
+LanguageSelector.propTypes = {
+  selectedLanguage: PropTypes.string.isRequired,
+  onSelectLanguage: PropTypes.func.isRequired
+};
+
+const mapStateToProps = ({ translation: { selectedLanguage } }) => ({
+  selectedLanguage
+});
+
+const mapDispatchToProps = dispatch => ({
+  onSelectLanguage: language => dispatch(selectLanguage(language))
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(LanguageSelector);

--- a/src/app/components/SearchForm.js
+++ b/src/app/components/SearchForm.js
@@ -1,10 +1,15 @@
+// React
 import React from 'react';
+import { intlShape } from 'react-intl';
+
+//Material-ui
 import Paper from 'material-ui/Paper';
 import { withStyles } from 'material-ui/styles';
-import styled from 'styled-components';
-
 import TextField from 'material-ui/TextField';
 import Grid from 'material-ui/Grid';
+
+//Styled-components
+import styled from 'styled-components';
 
 const styles = theme => ({
   root: {
@@ -46,6 +51,7 @@ let SearchButton = styled.button`
   cursor: pointer;
   height: 54px;
 `;
+
 class SearchForm extends React.Component {
   render() {
     const classes = this.props.classes;
@@ -59,8 +65,14 @@ class SearchForm extends React.Component {
                 <Paper className={classes.paper}>
                   <TextField
                     id="full-width"
-                    label="Je cherche un trajet de : "
-                    InputProps={{ placeholder: 'Indiquez ville ou pays' }}
+                    label={this.context.intl.formatMessage({
+                      id: 'components.search-form.from.label'
+                    })}
+                    InputProps={{
+                      placeholder: this.context.intl.formatMessage({
+                        id: 'components.search-form.from.placeholder'
+                      })
+                    }}
                     fullWidth
                     className={classes.TextField}
                     margin="normal"
@@ -71,8 +83,14 @@ class SearchForm extends React.Component {
                 <Paper className={classes.paper}>
                   <TextField
                     id="full-width"
-                    label="À : "
-                    InputProps={{ placeholder: 'Indiquez ville ou pays' }}
+                    label={this.context.intl.formatMessage({
+                      id: 'components.search-form.to.label'
+                    })}
+                    InputProps={{
+                      placeholder: this.context.intl.formatMessage({
+                        id: 'components.search-form.to.placeholder'
+                      })
+                    }}
                     fullWidth
                     className={classes.TextField}
                     margin="normal"
@@ -81,7 +99,11 @@ class SearchForm extends React.Component {
               </Grid>
               <Grid item xs={2}>
                 <Paper className={classes.paper}>
-                  <SearchButton>C'EST PARTI!</SearchButton>
+                  <SearchButton>
+                    {this.context.intl.formatMessage({
+                      id: 'components.search-form.buttons.submit'
+                    })}
+                  </SearchButton>
                 </Paper>
               </Grid>
             </Grid>
@@ -91,4 +113,9 @@ class SearchForm extends React.Component {
     );
   }
 }
+
+SearchForm.contextTypes = {
+  intl: intlShape.isRequired
+};
+
 export default withStyles(styles)(SearchForm);

--- a/src/app/components/Slider.js
+++ b/src/app/components/Slider.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import SearchForm from './SearchForm';
 import styled from 'styled-components';
 
@@ -29,9 +30,7 @@ let Slider = function() {
       <SliderWrapper>
         <ContainerWrapper>
           <SearchMessage>
-            <p>
-              Confiez vos colis et vos achats à des particuliers qui voyagent
-            </p>
+            <FormattedMessage id="pages.home.why-prompt" />
           </SearchMessage>
           <SearchForm />
         </ContainerWrapper>

--- a/src/app/components/__tests__/LanguageSelector.js
+++ b/src/app/components/__tests__/LanguageSelector.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import configureStore from 'redux-mock-store';
+import { mount } from 'enzyme';
+import '../../../test-util/enzyme-configuration';
+import LanguageSelectorContainer, {
+  LanguageSelector
+} from '../LanguageSelector';
+import createComponentWithIntl from '../../../test-util/create-component-with-intl';
+import createConnectedComponent from '../../../test-util/create-connected-component';
+
+import { selectLanguage } from '../../actions/translation';
+
+describe('LanguageSelector Component', () => {
+  it('renders without crashing', () => {
+    const div = document.createElement('div');
+    ReactDOM.render(
+      createComponentWithIntl(
+        <LanguageSelector selectedLanguage="en" onSelectLanguage={() => {}} />
+      ),
+      div
+    );
+  });
+
+  it('calls onSelectLanguage when a language is selected', () => {
+    const onSelectLanguage = jest.fn();
+
+    const languageSelector = mount(
+      createComponentWithIntl(
+        <LanguageSelector
+          selectedLanguage="fr"
+          onSelectLanguage={onSelectLanguage}
+        />
+      )
+    );
+
+    languageSelector
+      .find('select')
+      .simulate('change', { target: { value: 'en' } });
+
+    expect(onSelectLanguage.mock.calls.length).toBe(1);
+
+    expect(onSelectLanguage.mock.calls[0][0]).toBe('en');
+  });
+});
+
+describe('LanguageSelector Container', () => {
+  const mockStore = configureStore([])({
+    translation: {
+      selectedLanguage: 'fr'
+    }
+  });
+
+  const languageSelector = mount(
+    createConnectedComponent(
+      createComponentWithIntl(<LanguageSelectorContainer />),
+      { store: mockStore }
+    )
+  );
+
+  it('uses the selectedLanguage from the store', () => {
+    expect(languageSelector.find('select').props().value).toBe('fr');
+  });
+
+  it('dispatch a selectLanguage action when the language is changed', () => {
+    const expectedActions = [selectLanguage('en')];
+
+    languageSelector
+      .find('select')
+      .simulate('change', { target: { value: 'en' } });
+
+    expect(mockStore.getActions()).toEqual(expectedActions);
+  });
+});

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -1,0 +1,9 @@
+import englishTranslation from './translations/en';
+import frenchTranslation from './translations/fr';
+
+export const DEFAULT_LANGUAGE = 'en';
+
+export const AVAILABLE_LANGUAGES = {
+  en: englishTranslation,
+  fr: frenchTranslation
+};

--- a/src/app/reducers/__tests__/translation.js
+++ b/src/app/reducers/__tests__/translation.js
@@ -1,0 +1,40 @@
+import translation from '../translation';
+import { AVAILABLE_LANGUAGES, DEFAULT_LANGUAGE } from '../../constants';
+import { selectLanguage } from '../../actions/translation';
+
+describe('translation reducer', () => {
+  beforeAll(() => {
+    global.requestAnimationFrame = function(callback) {
+      setTimeout(callback, 0);
+    };
+  });
+
+  it('should return the initial state', () => {
+    expect(translation(undefined, {})).toEqual({
+      selectedLanguage: DEFAULT_LANGUAGE,
+      selectedTranslations: AVAILABLE_LANGUAGES[DEFAULT_LANGUAGE]
+    });
+  });
+
+  it('should handle select language when given a valid language', () => {
+    expect(translation(undefined, selectLanguage('fr'))).toEqual({
+      selectedLanguage: 'fr',
+      selectedTranslations: AVAILABLE_LANGUAGES['fr']
+    });
+  });
+
+  it('should not update selected language when given unavailable language', () => {
+    expect(
+      translation(
+        {
+          selectedLanguage: 'fr',
+          selectedTranslations: AVAILABLE_LANGUAGES['fr']
+        },
+        selectLanguage('ar')
+      )
+    ).toEqual({
+      selectedLanguage: 'fr',
+      selectedTranslations: AVAILABLE_LANGUAGES['fr']
+    });
+  });
+});

--- a/src/app/reducers/index.js
+++ b/src/app/reducers/index.js
@@ -1,0 +1,6 @@
+import { combineReducers } from 'redux';
+import translation from './translation';
+
+export default combineReducers({
+  translation
+});

--- a/src/app/reducers/translation.js
+++ b/src/app/reducers/translation.js
@@ -1,0 +1,27 @@
+import { handleActions } from 'redux-actions';
+import { DEFAULT_LANGUAGE, AVAILABLE_LANGUAGES } from '../constants';
+
+import { selectLanguage } from '../actions/translation';
+
+const INITIAL_STATE = {
+  selectedLanguage: DEFAULT_LANGUAGE,
+  selectedTranslations: AVAILABLE_LANGUAGES[DEFAULT_LANGUAGE]
+};
+
+export default handleActions(
+  {
+    [selectLanguage]: (state, { payload }) => {
+      const languageToSelect = payload.toLowerCase();
+
+      if (!AVAILABLE_LANGUAGES[languageToSelect]) {
+        return state;
+      }
+
+      return {
+        selectedLanguage: payload,
+        selectedTranslations: AVAILABLE_LANGUAGES[payload]
+      };
+    }
+  },
+  INITIAL_STATE
+);

--- a/src/app/translations/en.js
+++ b/src/app/translations/en.js
@@ -1,0 +1,17 @@
+export default {
+  'components.header.buttons.help': 'How does it work?',
+  'components.header.buttons.login': 'Log in',
+  'components.header.buttons.signup': 'Sign up',
+
+  'components.search-form.buttons.submit': "Let's go!",
+  'components.search-form.from.label': 'I want to ship from:',
+  'components.search-form.from.placeholder': 'Enter city to ship from',
+  'components.search-form.to.label': 'to:',
+  'components.search-form.to.placeholder': 'Enter city to ship to',
+
+  'languages.en': 'English',
+  'languages.fr': 'French',
+
+  'pages.home.title': 'Ship your stuff with Diaspoship!',
+  'pages.home.why-prompt': 'Let private individuals ship your parcels!'
+};

--- a/src/app/translations/fr.js
+++ b/src/app/translations/fr.js
@@ -1,0 +1,17 @@
+export default {
+  'components.header.buttons.help': 'Comment ça marche?',
+  'components.header.buttons.login': 'Se connecter',
+  'components.header.buttons.signup': "S'enregistrer",
+  'components.search-form.buttons.submit': "C'est parti!",
+  'components.search-form.from.label': 'Je cherche un trajet de:',
+  'components.search-form.from.placeholder': 'Indiquez ville ou pays',
+  'components.search-form.to.label': 'À:',
+  'components.search-form.to.placeholder': 'Indiquez ville ou pays',
+
+  'languages.en': 'Anglais',
+  'languages.fr': 'Français',
+
+  'pages.home.title': 'Envoyez vos colis avec Diaspoship',
+  'pages.home.why-prompt':
+    'Confiez vos colis et vos achats à des particuliers qui voyagent!'
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 // React libs
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { BrowserRouter } from 'react-router-dom';
+import { addLocaleData } from 'react-intl';
+import en from 'react-intl/locale-data/en';
+import fr from 'react-intl/locale-data/fr';
 
 // Workers
 import registerServiceWorker from './registerServiceWorker';
@@ -9,10 +11,8 @@ import registerServiceWorker from './registerServiceWorker';
 // App imports
 import App from './app/App';
 
-ReactDOM.render(
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>,
-  document.getElementById('root')
-);
+addLocaleData([...en, ...fr]);
+
+ReactDOM.render(<App />, document.getElementById('root'));
+
 registerServiceWorker();

--- a/src/test-util/create-component-with-intl.js
+++ b/src/test-util/create-component-with-intl.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import { DEFAULT_LANGUAGE, AVAILABLE_LANGUAGES } from '../app/constants';
+
+const createComponentWithIntl = (
+  children,
+  props = {
+    locale: DEFAULT_LANGUAGE,
+    messages: AVAILABLE_LANGUAGES[DEFAULT_LANGUAGE]
+  }
+) => {
+  return <IntlProvider {...props}>{children}</IntlProvider>;
+};
+
+export default createComponentWithIntl;

--- a/src/test-util/create-connected-component.js
+++ b/src/test-util/create-connected-component.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+
+const createConnectedComponent = (
+  children,
+  props = {
+    store: configureStore([])
+  }
+) => {
+  return <Provider {...props}>{children}</Provider>;
+};
+
+export default createConnectedComponent;

--- a/src/test-util/enzyme-configuration.js
+++ b/src/test-util/enzyme-configuration.js
@@ -1,0 +1,4 @@
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+configure({ adapter: new Adapter() });

--- a/yarn.lock
+++ b/yarn.lock
@@ -140,6 +140,10 @@
     react-treebeard "^2.0.3"
     redux "^3.6.0"
 
+"@types/node@^6.0.46":
+  version "6.0.88"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.88.tgz#f618f11a944f6a18d92b5c472028728a3e3d4b66"
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -1542,6 +1546,21 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
 
+body-parser@1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.2.tgz#87678a19d84b47d859b83199bd59bce222b10454"
+  dependencies:
+    bytes "3.0.0"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "~1.1.1"
+    http-errors "~1.6.2"
+    iconv-lite "0.4.19"
+    on-finished "~2.3.0"
+    qs "6.5.1"
+    raw-body "2.3.2"
+    type-is "~1.6.15"
+
 bonjour@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bonjour/-/bonjour-3.5.0.tgz#8e890a183d8ee9a2393b3844c691a42bcf7bc9f5"
@@ -1853,6 +1872,17 @@ change-emitter@^0.1.2:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
 
+cheerio@^1.0.0-rc.2:
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.0"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash "^4.15.0"
+    parse5 "^3.0.1"
+
 chokidar@^1.6.0, chokidar@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -1996,6 +2026,10 @@ colormin@^1.0.5:
     css-color-names "0.0.4"
     has "^1.0.1"
 
+colors@0.5.x:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
+
 colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
@@ -2105,7 +2139,7 @@ content-type-parser@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.1.tgz#c3e56988c53c65127fb46d4032a3a900246fdc94"
 
-content-type@~1.0.2:
+content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
@@ -2281,7 +2315,7 @@ css-loader@0.28.4, css-loader@^0.28.1:
     postcss-value-parser "^3.3.0"
     source-list-map "^0.1.7"
 
-css-select@^1.1.0:
+css-select@^1.1.0, css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
   dependencies:
@@ -2528,6 +2562,10 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+
 dns-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
@@ -2573,7 +2611,7 @@ dom-helpers@^3.2.0, dom-helpers@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
 
-dom-serializer@0:
+dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
   dependencies:
@@ -2594,7 +2632,7 @@ domain-browser@^1.1.1:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
 
-domelementtype@1:
+domelementtype@1, domelementtype@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
 
@@ -2608,13 +2646,19 @@ domhandler@2.1:
   dependencies:
     domelementtype "1"
 
+domhandler@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.1.tgz#892e47000a99be55bbf3774ffea0561d8879c259"
+  dependencies:
+    domelementtype "1"
+
 domutils@1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.1.6.tgz#bddc3de099b9a2efacc51c623f28f416ecc57485"
   dependencies:
     domelementtype "1"
 
-domutils@1.5.1:
+domutils@1.5.1, domutils@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
   dependencies:
@@ -2704,9 +2748,42 @@ enhanced-resolve@^3.4.0:
     object-assign "^4.0.1"
     tapable "^0.2.7"
 
-entities@~1.1.1:
+entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+
+enzyme-adapter-react-16@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.0.0.tgz#e7edd5536743818dcbef336d40d7da59b3a7db8e"
+  dependencies:
+    enzyme-adapter-utils "^1.0.0"
+    lodash "^4.17.4"
+    object.assign "^4.0.4"
+    object.values "^1.0.4"
+    prop-types "^15.5.10"
+
+enzyme-adapter-utils@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.0.0.tgz#e94eee63da9a798d498adb1162a2102ed04fc638"
+  dependencies:
+    lodash "^4.17.4"
+    object.assign "^4.0.4"
+    prop-types "^15.5.10"
+
+enzyme@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.0.0.tgz#94ce364254dc654c4e619b25eecc644bf6481de7"
+  dependencies:
+    cheerio "^1.0.0-rc.2"
+    function.prototype.name "^1.0.3"
+    is-subset "^0.1.1"
+    lodash "^4.17.4"
+    object-is "^1.0.1"
+    object.assign "^4.0.4"
+    object.entries "^1.0.4"
+    object.values "^1.0.4"
+    raf "^3.3.2"
+    rst-selector-parser "^2.2.1"
 
 errno@^0.1.3, errno@^0.1.4:
   version "0.1.4"
@@ -2987,7 +3064,7 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
-etag@~1.8.0, etag@~1.8.1:
+etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
 
@@ -3076,37 +3153,39 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
     homedir-polyfill "^1.0.1"
 
 express@^4.13.3, express@^4.15.3:
-  version "4.15.5"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.15.5.tgz#670235ca9598890a5ae8170b83db722b842ed927"
+  version "4.16.0"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.16.0.tgz#b519638e4eb58e7178c81b498ef22f798cb2e255"
   dependencies:
-    accepts "~1.3.3"
+    accepts "~1.3.4"
     array-flatten "1.1.1"
+    body-parser "1.18.2"
     content-disposition "0.5.2"
-    content-type "~1.0.2"
+    content-type "~1.0.4"
     cookie "0.3.1"
     cookie-signature "1.0.6"
     debug "2.6.9"
     depd "~1.1.1"
     encodeurl "~1.0.1"
     escape-html "~1.0.3"
-    etag "~1.8.0"
-    finalhandler "~1.0.6"
+    etag "~1.8.1"
+    finalhandler "1.1.0"
     fresh "0.5.2"
     merge-descriptors "1.0.1"
     methods "~1.1.2"
     on-finished "~2.3.0"
-    parseurl "~1.3.1"
+    parseurl "~1.3.2"
     path-to-regexp "0.1.7"
-    proxy-addr "~1.1.5"
-    qs "6.5.0"
+    proxy-addr "~2.0.2"
+    qs "6.5.1"
     range-parser "~1.2.0"
-    send "0.15.6"
-    serve-static "1.12.6"
-    setprototypeof "1.0.3"
+    safe-buffer "5.1.1"
+    send "0.16.0"
+    serve-static "1.13.0"
+    setprototypeof "1.1.0"
     statuses "~1.3.1"
     type-is "~1.6.15"
-    utils-merge "1.0.0"
-    vary "~1.1.1"
+    utils-merge "1.0.1"
+    vary "~1.1.2"
 
 extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
@@ -3246,9 +3325,9 @@ filled-array@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/filled-array/-/filled-array-1.1.0.tgz#c3c4f6c663b923459a9aa29912d2d031f1507f84"
 
-finalhandler@~1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.0.6.tgz#007aea33d1a4d3e42017f624848ad58d212f814f"
+finalhandler@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.0.tgz#ce0b6855b45853e791b2fcc680046d88253dd7f5"
   dependencies:
     debug "2.6.9"
     encodeurl "~1.0.1"
@@ -3334,7 +3413,7 @@ form-data@~2.3.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-forwarded@~0.1.0:
+forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
 
@@ -3724,7 +3803,7 @@ hoist-non-react-statics@1.x.x, hoist-non-react-statics@^1.0.0, hoist-non-react-s
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
 
-hoist-non-react-statics@^2.3.0:
+hoist-non-react-statics@^2.2.1, hoist-non-react-statics@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
 
@@ -3800,6 +3879,17 @@ html-webpack-plugin@2.29.0:
     pretty-error "^2.0.2"
     toposort "^1.0.0"
 
+htmlparser2@^3.9.1:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^2.0.2"
+
 htmlparser2@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.3.0.tgz#cc70d05a59f6542e43f0e685c982e14c924a9efe"
@@ -3813,7 +3903,7 @@ http-deceiver@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/http-deceiver/-/http-deceiver-1.2.7.tgz#fa7168944ab9a519d337cb0bec7284dc3e723d87"
 
-http-errors@~1.6.1, http-errors@~1.6.2:
+http-errors@1.6.2, http-errors@~1.6.1, http-errors@~1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
   dependencies:
@@ -3878,7 +3968,7 @@ iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
-iconv-lite@^0.4.17, iconv-lite@~0.4.13:
+iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
@@ -4007,7 +4097,27 @@ interpret@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.4.tgz#820cdd588b868ffb191a809506d6c9c8f212b1b0"
 
-invariant@2.x.x, invariant@^2.2.1, invariant@^2.2.2:
+intl-format-cache@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-2.0.5.tgz#b484cefcb9353f374f25de389a3ceea1af18d7c9"
+
+intl-messageformat-parser@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-1.2.0.tgz#5906b7f953ab7470e0dc8549097b648b991892ff"
+
+intl-messageformat@^2.0.0, intl-messageformat@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-2.1.0.tgz#1c51da76f02a3f7b360654cdc51bbc4d3fa6c72c"
+  dependencies:
+    intl-messageformat-parser "1.2.0"
+
+intl-relativeformat@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/intl-relativeformat/-/intl-relativeformat-2.0.0.tgz#d6ba9dc6c625819bc0abdb1d4e238138b7488f26"
+  dependencies:
+    intl-messageformat "^2.0.0"
+
+invariant@2.x.x, invariant@^2.0.0, invariant@^2.1.1, invariant@^2.2.1, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -4021,9 +4131,9 @@ ip@^1.1.0, ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
 
-ipaddr.js@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.4.0.tgz#296aca878a821816e5b85d0a285a99bcff4582f0"
+ipaddr.js@1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.5.2.tgz#d4b505bde9946987ccf0fc58d9010ff9607e3fa0"
 
 is-absolute-url@^2.0.0:
   version "2.1.0"
@@ -4237,6 +4347,10 @@ is-root@1.0.0:
 is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+is-subset@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
 
 is-svg@^2.0.0:
   version "2.1.0"
@@ -4592,14 +4706,14 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@3.6.1, js-yaml@^3.4.3:
+js-yaml@3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
   dependencies:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
-js-yaml@^3.7.0, js-yaml@^3.9.1:
+js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@^3.9.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -4958,7 +5072,7 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.2.1:
+lodash-es@^4.17.4, lodash-es@^4.2.0, lodash-es@^4.2.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
 
@@ -5043,7 +5157,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@4.x.x, "lodash@>=3.5 <5", lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
+lodash@4.x.x, "lodash@>=3.5 <5", lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -5258,13 +5372,13 @@ mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.17, 
   dependencies:
     mime-db "~1.30.0"
 
-mime@1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
-
 mime@1.3.x, mime@^1.3.4:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.6.tgz#591d84d3653a6b0b4a3b9df8de5aa8108e72e5e0"
+
+mime@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
 
 mimic-fn@^1.0.0:
   version "1.1.0"
@@ -5346,6 +5460,14 @@ ncname@1.0.x:
   resolved "https://registry.yarnpkg.com/ncname/-/ncname-1.0.0.tgz#5b57ad18b1ca092864ef62b0b1ed8194f383b71c"
   dependencies:
     xml-char-classes "^1.0.0"
+
+nearley@^2.7.10:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.11.0.tgz#5e626c79a6cd2f6ab9e7e5d5805e7668967757ae"
+  dependencies:
+    nomnom "~1.6.2"
+    railroad-diagrams "^1.0.0"
+    randexp "^0.4.2"
 
 negotiator@0.6.1:
   version "0.6.1"
@@ -5433,6 +5555,13 @@ node-pre-gyp@^0.6.36:
 node-status-codes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-status-codes/-/node-status-codes-1.0.0.tgz#5ae5541d024645d32a58fcddc9ceecea7ae3ac2f"
+
+nomnom@~1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.6.2.tgz#84a66a260174408fc5b77a18f888eccc44fb6971"
+  dependencies:
+    colors "0.5.x"
+    underscore "~1.4.4"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -5532,9 +5661,21 @@ object-hash@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.1.8.tgz#28a659cf987d96a4dabe7860289f3b5326c4a03c"
 
-object-keys@^1.0.8:
+object-is@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
+
+object-keys@^1.0.10, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+
+object.assign@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.0.4.tgz#b1c9cc044ef1b9fe63606fc141abbb32e14730cc"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.0"
+    object-keys "^1.0.10"
 
 object.entries@^1.0.4:
   version "1.0.4"
@@ -5750,6 +5891,12 @@ parse-passwd@^1.0.0:
 parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
+
+parse5@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.2.tgz#05eff57f0ef4577fb144a79f8b9a967a6cc44510"
+  dependencies:
+    "@types/node" "^6.0.46"
 
 parseurl@~1.3.1, parseurl@~1.3.2:
   version "1.3.2"
@@ -6259,12 +6406,16 @@ prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8,
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-proxy-addr@~1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.5.tgz#71c0ee3b102de3f202f3b64f608d173fcba1a918"
+proptypes@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proptypes/-/proptypes-1.1.0.tgz#78b3828a5aa6bb1308939e0de3c6044dfd4bd239"
+
+proxy-addr@~2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.2.tgz#6571504f47bb988ec8180253f85dd7e14952bdec"
   dependencies:
-    forwarded "~0.1.0"
-    ipaddr.js "1.4.0"
+    forwarded "~0.1.2"
+    ipaddr.js "1.5.2"
 
 prr@~0.0.0:
   version "0.0.0"
@@ -6296,11 +6447,7 @@ q@^1.1.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.0.tgz#dd01bac9d06d30e6f219aecb8253ee9ebdc308f1"
 
-qs@6.5.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.0.tgz#8d04954d364def3efc55b5a0793e1e2c8b1e6e49"
-
-qs@^6.4.0, qs@~6.5.1:
+qs@6.5.1, qs@^6.4.0, qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
@@ -6344,11 +6491,28 @@ radium@^0.19.0:
     inline-style-prefixer "^2.0.5"
     prop-types "^15.5.8"
 
+raf@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.3.2.tgz#0c13be0b5b49b46f76d6669248d527cf2b02fe27"
+  dependencies:
+    performance-now "^2.1.0"
+
 rafl@~1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/rafl/-/rafl-1.2.2.tgz#fe930f758211020d47e38815f5196a8be4150740"
   dependencies:
     global "~4.3.0"
+
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+
+randexp@^0.4.2:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
 
 randomatic@^1.1.3:
   version "1.1.7"
@@ -6366,6 +6530,15 @@ randombytes@^2.0.0, randombytes@^2.0.1:
 range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
+
+raw-body@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.2.tgz#bcd60c77d3eb93cde0050295c3f379389bc88f89"
+  dependencies:
+    bytes "3.0.0"
+    http-errors "1.6.2"
+    iconv-lite "0.4.19"
+    unpipe "1.0.0"
 
 rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
   version "1.2.1"
@@ -6480,6 +6653,15 @@ react-inspector@^2.1.6:
     babel-runtime "^6.23.0"
     is-dom "^1.0.9"
 
+react-intl@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-2.4.0.tgz#66c14dc9df9a73b2fbbfbd6021726e80a613eb15"
+  dependencies:
+    intl-format-cache "^2.0.5"
+    intl-messageformat "^2.1.0"
+    intl-relativeformat "^2.0.0"
+    invariant "^2.1.1"
+
 react-jss@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/react-jss/-/react-jss-7.2.0.tgz#30a5ed51d8388a33767c6d19790b222c1f33f48f"
@@ -6523,6 +6705,17 @@ react-popper@^0.7.2:
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-0.7.3.tgz#fa2809a80fbe7ec516e9bac01d81bc47a8b5cd3b"
   dependencies:
     popper.js "^1.12.5"
+    prop-types "^15.5.10"
+
+react-redux@^5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.6.tgz#23ed3a4f986359d68b5212eaaa681e60d6574946"
+  dependencies:
+    hoist-non-react-statics "^2.2.1"
+    invariant "^2.0.0"
+    lodash "^4.2.0"
+    lodash-es "^4.2.0"
+    loose-envify "^1.1.0"
     prop-types "^15.5.10"
 
 react-router-dom@^4.2.2:
@@ -6631,6 +6824,13 @@ react-style-proptype@^3.0.0:
   resolved "https://registry.yarnpkg.com/react-style-proptype/-/react-style-proptype-3.0.0.tgz#89e0b646f266c656abb0f0dd8202dbd5036c31e6"
   dependencies:
     prop-types "^15.5.4"
+
+react-test-renderer@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.0.0.tgz#9fe7b8308f2f71f29fc356d4102086f131c9cb15"
+  dependencies:
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
 
 react-transition-group@^1.1.2:
   version "1.2.0"
@@ -6802,7 +7002,24 @@ reduce-function-call@^1.0.1:
   dependencies:
     balanced-match "^0.4.2"
 
-redux@^3.6.0:
+reduce-reducers@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/reduce-reducers/-/reduce-reducers-0.1.2.tgz#fa1b4718bc5292a71ddd1e5d839c9bea9770f14b"
+
+redux-actions@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/redux-actions/-/redux-actions-2.2.1.tgz#d64186b25649a13c05478547d7cd7537b892410d"
+  dependencies:
+    invariant "^2.2.1"
+    lodash "^4.13.1"
+    lodash-es "^4.17.4"
+    reduce-reducers "^0.1.0"
+
+redux-mock-store@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.3.0.tgz#6edfef0d2332f20576381069d6d889a6d0a4451c"
+
+redux@^3.6.0, redux@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
   dependencies:
@@ -7053,6 +7270,10 @@ restore-cursor@^2.0.0:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
 
+ret@~0.1.10:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
+
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
@@ -7075,6 +7296,13 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^2.0.0"
     inherits "^2.0.1"
+
+rst-selector-parser@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/rst-selector-parser/-/rst-selector-parser-2.2.2.tgz#9927b619bd5af8dc23a76c64caef04edf90d2c65"
+  dependencies:
+    lodash.flattendeep "^4.4.0"
+    nearley "^2.7.10"
 
 run-async@^2.2.0:
   version "2.3.0"
@@ -7150,9 +7378,9 @@ semver-diff@^2.0.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
-send@0.15.6:
-  version "0.15.6"
-  resolved "https://registry.yarnpkg.com/send/-/send-0.15.6.tgz#20f23a9c925b762ab82705fe2f9db252ace47e34"
+send@0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.16.0.tgz#16338dbb9a2ede4ad57b48420ec3b82d8e80a57b"
   dependencies:
     debug "2.6.9"
     depd "~1.1.1"
@@ -7162,7 +7390,7 @@ send@0.15.6:
     etag "~1.8.1"
     fresh "0.5.2"
     http-errors "~1.6.2"
-    mime "1.3.4"
+    mime "1.4.1"
     ms "2.0.0"
     on-finished "~2.3.0"
     range-parser "~1.2.0"
@@ -7190,14 +7418,14 @@ serve-index@^1.7.2:
     mime-types "~2.1.15"
     parseurl "~1.3.1"
 
-serve-static@1.12.6:
-  version "1.12.6"
-  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.12.6.tgz#b973773f63449934da54e5beba5e31d9f4211577"
+serve-static@1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.13.0.tgz#810c91db800e94ba287eae6b4e06caab9fdc16f1"
   dependencies:
     encodeurl "~1.0.1"
     escape-html "~1.0.3"
     parseurl "~1.3.2"
-    send "0.15.6"
+    send "0.16.0"
 
 serviceworker-cache-polyfill@^4.0.0:
   version "4.0.0"
@@ -7218,6 +7446,10 @@ setimmediate@^1.0.4, setimmediate@^1.0.5:
 setprototypeof@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
+
+setprototypeof@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
 
 settle-promise@1.0.0:
   version "1.0.0"
@@ -7585,8 +7817,8 @@ styled-components@^2.1.2:
     supports-color "^3.2.3"
 
 stylis@^3.2.1:
-  version "3.2.18"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.2.18.tgz#211661f13b636e9e451456a1aadcec31248edf0e"
+  version "3.2.19"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.2.19.tgz#3bfeff425e12935cde5faed4a39de06b1aeb5acb"
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -7870,6 +8102,10 @@ underscore@^1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
+underscore@~1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
+
 uniq@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
@@ -7894,7 +8130,7 @@ universalify@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
-unpipe@~1.0.0:
+unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
 
@@ -7975,9 +8211,9 @@ utila@~0.4:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
 
-utils-merge@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
+utils-merge@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
 
 uuid@^2.0.1, uuid@^2.0.2:
   version "2.0.3"
@@ -7998,7 +8234,7 @@ value-equal@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
 
-vary@~1.1.1, vary@~1.1.2:
+vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
 


### PR DESCRIPTION
#5. On ajoute le support de l'internalisation via react-intl. Pour l'instant nous ne sommes pas encore responsive.

![diaspoship-web-i18n](https://user-images.githubusercontent.com/3483656/31057132-8111b176-a6ab-11e7-8a64-119d55007168.gif)
