### PR TITLE
Fix some issues with latest update of material-ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10116,9 +10116,9 @@
       "dev": true
     },
     "material-ui": {
-      "version": "1.0.0-beta.29",
-      "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-1.0.0-beta.29.tgz",
-      "integrity": "sha512-l0QDFy5gmwiFRq1azgBHlhGu/aZbGPwcHKezwTTDXIxuEkOzC1fpJb2Zv+wCileAW1s1NJx5hAN2lh2E/xeVxQ==",
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-1.0.0-beta.30.tgz",
+      "integrity": "sha512-cgUUYf+sXjkUQmImjngHPmwo6kBIfvZKrNxmp56cpATYyaeoBydfERwv9SfUu1zzJyXLhJ6tt17XeUBn8aSqug==",
       "requires": {
         "@types/jss": "9.3.0",
         "@types/react-transition-group": "2.0.6",
@@ -12399,11 +12399,6 @@
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1"
       }
-    },
-    "proptypes": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proptypes/-/proptypes-1.1.0.tgz",
-      "integrity": "sha1-eLOCilqmuxMIk54N48YETf1L0jk="
     },
     "proxy-addr": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "dependencies": {
     "classnames": "^2.2.5",
-    "material-ui": "^1.0.0-beta.17",
+    "jss-extend": "^6.1.0",
+    "jss-preset-default": "^4.1.0",
+    "material-ui": "^1.0.0-beta.30",
     "material-ui-icons": "^1.0.0-beta.17",
     "moment": "^2.19.1",
     "prop-types": "^15.6.0",

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -14,6 +14,14 @@ import { initializeFacebookSDK } from './actions/session';
 import Offer from './container/Offer';
 //Material UI
 import { withStyles } from 'material-ui/styles';
+import { create as createJss } from 'jss';
+import { JssProvider } from 'react-jss';
+import jssExtend from 'jss-extend';
+import jssPressetDefault from 'jss-preset-default';
+
+const jss = createJss(jssPressetDefault());
+
+jss.use(jssExtend());
 
 const styles = theme => ({
   root: {
@@ -29,7 +37,11 @@ store.dispatch(selectLanguage(window.navigator.language.split('-')[0]));
 store.dispatch(initializeFacebookSDK());
 
 const AppBody = ({ selectedLanguage, selectedTranslations, classes }) => (
-  <IntlProvider locale={selectedLanguage} messages={selectedTranslations}>
+  <IntlProvider
+    key={selectedLanguage}
+    locale={selectedLanguage}
+    messages={selectedTranslations}
+  >
     <Router>
       <div>
         <HelmetIntl messageId="pages.home.title" />
@@ -57,9 +69,11 @@ const mapStateToProps = ({
 const AppBodyWithState = connect(mapStateToProps)(withStyles(styles)(AppBody));
 
 const App = () => (
-  <Provider store={store}>
-    <AppBodyWithState />
-  </Provider>
+  <JssProvider jss={jss}>
+    <Provider store={store}>
+      <AppBodyWithState />
+    </Provider>
+  </JssProvider>
 );
 
 export default App;

--- a/src/app/components/Header/index.js
+++ b/src/app/components/Header/index.js
@@ -49,14 +49,14 @@ function Header({ classes, intl: { formatMessage }, ...props }) {
         </Typography>
         <UserStatus />
         <IconButton
-          color="contrast"
+          color="inherit"
           aria-label={helpButtonText}
           className={classes.toolbarButtonWithoutText}
         >
           <HelpIcon />
         </IconButton>
         <Button
-          color="contrast"
+          color="inherit"
           aria-label={helpButtonText}
           className={classes.toolbarButtonWithText}
         >

--- a/src/app/components/LanguageSelector/index.js
+++ b/src/app/components/LanguageSelector/index.js
@@ -42,7 +42,7 @@ class LanguageSelector extends React.PureComponent {
     return (
       <div>
         <IconButton
-          color="contrast"
+          color="inherit"
           aria-label={this.context.intl.formatMessage({
             id: 'components.language-selector.label'
           })}

--- a/src/app/components/Offer/index.js
+++ b/src/app/components/Offer/index.js
@@ -186,6 +186,7 @@ class OfferComponent extends React.Component {
 OfferComponent.contextTypes = {
   intl: intlShape.isRequired
 };
+
 OfferComponent.propTypes = {
   classes: PropTypes.object.isRequired,
   fetchOffer: PropTypes.func.isRequired,

--- a/src/app/components/OfferList/OfferThumbnail.js
+++ b/src/app/components/OfferList/OfferThumbnail.js
@@ -1,6 +1,7 @@
 // React
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 //Material-UI
 import Card, { CardContent } from 'material-ui/Card';
 import { withStyles } from 'material-ui/styles';
@@ -10,13 +11,14 @@ import classNames from 'classnames';
 //App
 import OfferType from '../../types/offer';
 
-const styles = theme => ({
-  root: {
+const styles = () => ({
+  offerThumbnail: {
     display: 'flex',
     flex: '1 0 auto',
     flexDirection: 'column',
     lineHeight: '20px',
-    color: 'rgba(0, 0, 0, 0.87)'
+    color: 'rgba(0, 0, 0, 0.87)',
+    textTransform: 'none'
   },
 
   contentRow: {
@@ -58,7 +60,7 @@ const styles = theme => ({
 });
 
 const OfferThumbnail = ({ offer, classes, className, ...props }) => (
-  <Card className={classNames(classes.root, className)} {...props}>
+  <Card className={classNames(classes.offerThumbnail, className)} {...props}>
     <CardContent>
       <div className={classes.destinationRow}>
         <span className={classes.from}> {offer.from} </span>
@@ -72,7 +74,9 @@ const OfferThumbnail = ({ offer, classes, className, ...props }) => (
       </div>
       <div className={classes.pricingRow}>
         <span className={classes.pricingItem}>{offer.availableKg}</span>
-        <span className={classes.pricingItem}> à </span>
+        <FormattedMessage id="components.offer-list.thumbnail.pricing.to">
+          {txt => <span className={classes.pricingItem}>{txt}</span>}
+        </FormattedMessage>
         <span className={classes.priceItem}>
           {offer.pricePerKg} {offer.currencyUnit}/Kg
         </span>

--- a/src/app/components/OfferList/index.js
+++ b/src/app/components/OfferList/index.js
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { withRouter } from 'react-router-dom';
 //Material-UI
-import Paper from 'material-ui/Paper';
 import { LinearProgress } from 'material-ui/Progress';
+import Button from 'material-ui/Button';
 import { withStyles } from 'material-ui/styles';
 import classNames from 'classnames';
 //App
@@ -20,8 +20,8 @@ const styles = theme => ({
   offerListContent: {
     display: 'flex',
     flexDirection: 'column',
-    justifyContent: 'space-between',
     padding: '5px',
+    justifyContent: 'space-between',
     flexWrap: 'wrap',
     [theme.breakpoints.up('sm')]: {
       flexDirection: 'row'
@@ -32,10 +32,12 @@ const styles = theme => ({
     padding: '10px 20px'
   },
 
-  offerThumbnail: {
+  offerThumbnailButton: {
     margin: '5px',
+    padding: 0,
     [theme.breakpoints.up('sm')]: {
-      flexBasis: '30%'
+      flex: '1 1 280px',
+      minWidth: '280px'
     }
   }
 });
@@ -67,7 +69,7 @@ class OfferListComponent extends React.Component {
     } = this.props;
 
     return (
-      <Paper className={classNames(classes.root, className)}>
+      <div className={classNames(classes.root, className)}>
         <div className={classes.offerListHeader}>
           <h4>
             <FormattedMessage id="components.offer-list.header.noFilters" />
@@ -79,16 +81,18 @@ class OfferListComponent extends React.Component {
         ) : (
           <div className={classes.offerListContent}>
             {offers.map(offer => (
-              <OfferThumbnail
-                className={classes.offerThumbnail}
-                onClick={() => history.push(`/offers/${offer.id}`)}
+              <Button
+                raised
                 key={offer.id}
-                offer={offer}
-              />
+                onClick={() => history.push(`/offers/${offer.id}`)}
+                className={classes.offerThumbnailButton}
+              >
+                <OfferThumbnail offer={offer} />
+              </Button>
             ))}
           </div>
         )}
-      </Paper>
+      </div>
     );
   }
 }

--- a/src/app/components/Profile/Login.js
+++ b/src/app/components/Profile/Login.js
@@ -30,16 +30,16 @@ const Login = function({ classes, intl: { formatMessage }, ...props }) {
   return (
     <div>
       <IconButton
+        color="inherit"
         onClick={props.onLogin}
-        color="contrast"
         aria-label={loginButtonText}
         className={classes.toolbarButtonWithoutText}
       >
         <AccountIcon />
       </IconButton>
       <Button
+        color="inherit"
         onClick={props.onLogin}
-        color="contrast"
         aria-label={loginButtonText}
         className={classes.toolbarButtonWithText}
       >

--- a/src/app/translations/en.js
+++ b/src/app/translations/en.js
@@ -21,6 +21,7 @@ export default {
   'components.offer-list.header.error':
     'An error occurred while searching for offers',
   'components.offer-list.header.noFilters': 'Latest offers',
+  'components.offer-list.thumbnail.pricing.to': 'to',
 
   'languages.en': 'English',
   'languages.fr': 'French',

--- a/src/app/translations/fr.js
+++ b/src/app/translations/fr.js
@@ -21,6 +21,7 @@ export default {
   'components.offer-list.header.error':
     'Une erreur est survenue lors de la recherche des offres',
   'components.offer-list.header.noFilters': 'Offres récentes',
+  'components.offer-list.thumbnail.pricing.to': 'à',
 
   'languages.en': 'Anglais',
   'languages.fr': 'Français',


### PR DESCRIPTION
- On avait certains fuck avec l'update de material-ui à beta 30. Notamment contrast qui a été deprecated et certains plugins jss (extend par exemple) qui n'était plus utilisé par défaut.
On remet donc ce plugin et on change contrast part inherit comme requis dans le guide.

Lien: https://github.com/mui-org/material-ui/releases/tag/v1.0.0-beta.30

- J'en ai aussi profité pour mettre à jour le layout
![localhost_3000_ 1](https://user-images.githubusercontent.com/3483656/35477812-7321854a-039a-11e8-9759-5695eb889769.png)
